### PR TITLE
Fix portability issue

### DIFF
--- a/dotfiles
+++ b/dotfiles
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 REPO_PATH="${HOME}/.dotfiles"
 MAP_FILE="dotfiles.map"

--- a/dotfiles
+++ b/dotfiles
@@ -45,8 +45,13 @@ function local_file_add () {
   local file="$1"
   local repo_file="$2"
   local commit_msg="Added: $local_file -> $repo_file"
+  if [[ "$OSTYPE" == "darwin11" ]]; then
+    local linkcmd="ln"
+  else
+    local linkcmd="cp -l"
+  fi
 
-  cp -l "$file" "$repo_file" &&
+  $linkcmd "$file" "$repo_file" &&
   git add "$repo_file" &&
   git commit -m "$commit_msg"
 }


### PR DESCRIPTION
- Use `link` instead of `cp -l` on OS X, since the `-l` flag is not supported.
- Change shebang to lookup bash in PATH. Ran across this problem on FreeBSD 9.0.
